### PR TITLE
Fix systemctl check

### DIFF
--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -15,7 +15,7 @@
       delay: 5
       when: ansible_service_mgr == 'systemd'
       changed_when: false
-      failed_when: systemctl_status.rc > 0
+      failed_when: systemctl_status.rc > 1
 
   roles:
     - role: mirsg.java


### PR DESCRIPTION
Changes:

In the molecule converge playbook there is a `pre_task` for checking that `systemd` is running. This checks for `running` or `degraded` in the `stdout` of the command `systemctl is-system-running`. This means that the return code should accept a return code of `1`. This means that instead of:

```yaml
failed_when: systemctl_status.rc > 0
```

it should be:

```yaml
failed_when: systemctl_status.rc > 1
```
